### PR TITLE
Add image URL input with preview

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,41 @@
-import { Text, View } from "react-native";
+import { useState } from "react";
+import { Text, View, TextInput } from "react-native";
+import { Image } from "expo-image";
 
 export default function Index() {
+  const [imageUrl, setImageUrl] = useState("");
+
   return (
     <View
       style={{
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
+        padding: 16,
       }}
     >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
+      <Text style={{ marginBottom: 8 }}>Enter image URL:</Text>
+      <TextInput
+        value={imageUrl}
+        onChangeText={setImageUrl}
+        placeholder="https://example.com/image.jpg"
+        autoCapitalize="none"
+        style={{
+          width: "100%",
+          borderWidth: 1,
+          borderColor: "#ccc",
+          borderRadius: 4,
+          padding: 8,
+          marginBottom: 16,
+        }}
+      />
+      {imageUrl ? (
+        <Image
+          source={{ uri: imageUrl }}
+          style={{ width: 200, height: 200 }}
+          contentFit="contain"
+        />
+      ) : null}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- allow users to type in an image URL
- show a preview using `expo-image`

## Testing
- `npm run lint` *(fails: expo not found)*